### PR TITLE
No OLED, No Problem

### DIFF
--- a/HenryBMESH/HenryBMESH.ino
+++ b/HenryBMESH/HenryBMESH.ino
@@ -10,7 +10,7 @@ void setup() {
 
   if (!oled.begin()) {
     Serial.println(F("Failed to start OLED"));
-    while (true);
+    //while (true);
   }
   // 1. Clear the screen buffer
   oled.clear();


### PR DESCRIPTION
If a board does not have a SSD1306 OLED, the code will keep running.  Commented out while (true); in oled.begin();  why was this there?